### PR TITLE
update link to ref specific commit within enspiral handbook

### DIFF
--- a/agreements/diversity-agreement.md
+++ b/agreements/diversity-agreement.md
@@ -1,1 +1,1 @@
-{% include "git+https://github.com/enspiral/handbook.git/diversity_agreement.md" %}
+{% include "git+https://github.com/enspiral/handbook/blob/634be8f0686f3e4f6446d010482043f5a92c187f/diversity_agreement.md" %}

--- a/agreements/diversity-agreement.md
+++ b/agreements/diversity-agreement.md
@@ -1,1 +1,1 @@
-{% include "git+https://github.com/enspiral/handbook/blob/634be8f0686f3e4f6446d010482043f5a92c187f/diversity_agreement.md" %}
+{% include "git+https://github.com/enspiral/handbook.git/diversity_agreement.md#634be8f0686f3e4f6446d010482043f5a92c187f" %}


### PR DESCRIPTION
@ahdinosaur can you check this one as well :) 

This will mean we are referencing a specific commit, so we will have to manually update the reference to if a patch to the agreement was made in enspiral.handbook