### PR TITLE
move networks on ecosystem page to networks section

### DIFF
--- a/context/ecosystem.md
+++ b/context/ecosystem.md
@@ -17,14 +17,11 @@
 ## Networks
 
 - [Enspiral](https://enspiral.com/)
-
-## Platforms
-
-- [platforms](http://platformcoop.net/)
+- [Platform Coops](http://platformcoop.net/)
+- [Open App Ecosystem](https://github.com/open-app/core)
+- [Collaborative Technology Alliance](https://medium.com/enspiral-tales/doing-more-together-together-seeding-a-collaborative-technology-alliance-82243ea30d41)
 
 ## Protocols
 
-- [Secure Scuttlebutt Consortium](https://www.scuttlebutt.nz)
-- [Value Flows](https://valueflo.ws))
-- [Open App Ecosystem](https://github.com/open-app/core)
-- [Collaborative Technology Alliance](https://medium.com/enspiral-tales/doing-more-together-together-seeding-a-collaborative-technology-alliance-82243ea30d41)
+- [Secure Scuttlebutt](https://www.scuttlebutt.nz)
+- [Value Flows](https://www.valueflo.ws)


### PR DESCRIPTION
and remove platforms section.

but might be only me who sees it this way.